### PR TITLE
Security Fix (HSTS)

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,3 @@
+# Redirects WWW to HTTPS and then redirects back to naked domain (to resolve HSTS issues for WWW)
+http://www.cbcf.info/* https://www.cbcf.info/:splat 301!
+https://www.cbcf.info/* https://cbcf.info/:splat 301!


### PR DESCRIPTION
Fix for issue on www.cbcf.info with redirects (causing HSTS policy to not be applied correctly which means site audit fails for security compliance).